### PR TITLE
Implement draw probability in simulations

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -244,8 +244,15 @@ def _simulate_table(
             away_lambda = 1.0
 
     for _, row in remaining.iterrows():
-        hs = int(rng.poisson(home_lambda * ha))
-        as_ = int(rng.poisson(away_lambda))
+        if rng.random() < tie_prob:
+            lam = (home_lambda * ha + away_lambda) / 2
+            g = int(rng.poisson(lam))
+            hs = as_ = g
+        else:
+            hs = as_ = 0
+            while hs == as_:
+                hs = int(rng.poisson(home_lambda * ha))
+                as_ = int(rng.poisson(away_lambda))
         sims.append(
             {
                 "date": row["date"],


### PR DESCRIPTION
## Summary
- allow `_simulate_table` to control draw probability
- update unit tests for new tie behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aca2afe3883258082afa60a680b1b