### PR TITLE
Allow setting draw probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ simulate from that point forward. You can control the home team's scoring
 advantage using `--home-advantage <multiplier>` (default is
 `DEFAULT_HOME_FIELD_ADVANTAGE`). Goal rates for home and away sides are
 estimated from the played matches and scores are drawn from Poisson
-distributions.
+distributions. The default chance of a draw is 33.3%% but can be adjusted with
+`--tie-percent <value>`.
 
 `DEFAULT_JOBS` still defines the parallelism level.
 
@@ -68,8 +69,9 @@ from simulator import (
 All simulation functions accept an optional ``n_jobs`` argument to control the
 degree of parallelism. By default ``n_jobs`` is set to the number of CPU cores,
 so simulations automatically run in parallel. When ``n_jobs`` is greater than
-one, joblib is used to distribute the work across multiple workers. The tie
-percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
+one, joblib is used to distribute the work across multiple workers. The draw
+probability defaults to 33.3%% and the home advantage to 1.0. Both can be
+overridden via ``--tie-percent`` and ``--home-advantage``.
 
 ## License
 

--- a/main.py
+++ b/main.py
@@ -66,6 +66,12 @@ def main() -> None:
         default=DEFAULT_HOME_FIELD_ADVANTAGE,
         help="multiplier for home team goal rate",
     )
+    parser.add_argument(
+        "--tie-percent",
+        type=float,
+        default=DEFAULT_TIE_PERCENT,
+        help="percent chance of a match ending in a draw",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -73,8 +79,8 @@ def main() -> None:
         from_date = pd.to_datetime(args.from_date)
         matches.loc[matches["date"] >= from_date, ["home_score", "away_score"]] = np.nan
     rng = np.random.default_rng(args.seed) if args.seed is not None else None
-    # Fixed simulation parameters
-    tie_prob = DEFAULT_TIE_PERCENT / 100.0
+    # Convert tie percent option into probability
+    tie_prob = args.tie_percent / 100.0
 
     summary = summary_table(
         matches,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,6 +7,7 @@ from .simulator import (
     home_goal_rate,
     away_goal_rate,
     estimate_home_field_advantage,
+    DEFAULT_TIE_PERCENT,
     simulate_chances,
     simulate_relegation_chances,
     simulate_final_table,
@@ -24,4 +25,5 @@ __all__ = [
     "simulate_relegation_chances",
     "simulate_final_table",
     "summary_table",
+    "DEFAULT_TIE_PERCENT",
 ]


### PR DESCRIPTION
## Summary
- expose `DEFAULT_TIE_PERCENT` in `src.__init__`
- add `--tie-percent` CLI option in `main.py`
- document draw probability option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aced9e81483259fc5241946ed9e09