### PR TITLE
Add goal correlation parameter using rho

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ command line. `DEFAULT_JOBS` still defines the parallelism level.
 Pass `--home-goals-mean` and `--away-goals-mean` to sample scores from Poisson
 distributions with the given expected values instead of the basic win/draw/loss
 model. These options can also be provided programmatically via the simulation
-functions.
+functions. An optional `rho` parameter can be supplied alongside the expected
+goals to introduce correlation between the home and away scorelines.
 
 Alternatively, pass `--auto-calibrate` to estimate these parameters using all
 historical files in the `data/` directory. The computed draw rate and home
@@ -97,7 +98,8 @@ so simulations automatically run in parallel. When ``n_jobs`` is greater than
 one, joblib is used to distribute the work across multiple workers. The tie
 percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
 Provide expected goal values via ``home_goals_mean`` and ``away_goals_mean`` to
-enable Poisson-based scoring.
+enable Poisson-based scoring. Add ``rho`` to correlate the home and away goal
+processes when desired.
 
 ## License
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -385,6 +385,63 @@ def test_poisson_mode_repeatable():
     pd.testing.assert_frame_equal(t1, t2)
 
 
+def test_correlated_poisson_repeatable():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    rng = np.random.default_rng(321)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.4,
+        away_goals_mean=1.1,
+        rho=0.3,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(321)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.4,
+        away_goals_mean=1.1,
+        rho=0.3,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
+def test_simulate_table_invalid_rho():
+    played, remaining = _minimal_matches()
+    rng = np.random.default_rng(10)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(
+            played,
+            remaining,
+            rng,
+            home_goals_mean=1.0,
+            away_goals_mean=1.0,
+            rho=1.2,
+        )
+    with pytest.raises(ValueError):
+        simulator._simulate_table(
+            played,
+            remaining,
+            rng,
+            home_goals_mean=1.0,
+            away_goals_mean=1.0,
+            rho=-1.1,
+        )
+    with pytest.raises(ValueError):
+        simulator._simulate_table(
+            played,
+            remaining,
+            rng,
+            rho=0.2,
+        )
+
+
 def test_simulate_table_invalid_goal_means():
     played, remaining = _minimal_matches()
     rng = np.random.default_rng(3)


### PR DESCRIPTION
## Summary
- allow `_simulate_table` to accept optional `rho` and generate correlated Poisson scores
- expose `rho` through public simulation functions
- document `rho` parameter and add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689003fea67883258ef20c75f4ab476c