### PR TITLE
feat: add seasonal decay weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ advantage are then used for the simulation. Combine this flag with
 `--auto-team-strengths` to automatically incorporate team quality estimates.
 
 Use ``estimate_team_strengths`` to calculate attack and defense multipliers for
-each club:
+each club.  Pass multiple seasons and an optional ``decay`` factor to weigh
+recent results more heavily:
 
 ```python
 from calibration import estimate_team_strengths
-strengths = estimate_team_strengths(["data/Brasileirao2024A.txt"])
+strengths = estimate_team_strengths([
+    "data/Brasileirao2024A.txt",
+    "data/Brasileirao2023A.txt",
+], decay=0.9)
 ```
 
 Pass ``strengths`` via the ``team_params`` argument when calling the simulation

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -83,7 +83,9 @@ def estimate_goal_means(paths: List[str]) -> tuple[float, float]:
     return home_goals_mean, away_goals_mean
 
 
-def estimate_team_strengths(paths: List[str]) -> Dict[str, tuple[float, float]]:
+def estimate_team_strengths(
+    paths: List[str], decay: float | None = None
+) -> Dict[str, tuple[float, float]]:
     """Estimate attack and defense multipliers for each team.
 
     The returned values are normalized so that ``1.0`` represents league
@@ -94,6 +96,12 @@ def estimate_team_strengths(paths: List[str]) -> Dict[str, tuple[float, float]]:
     ----------
     paths:
         A list of text file paths containing historical fixtures with results.
+        Files should be ordered from most recent to oldest when using
+        ``decay``.
+    decay:
+        Optional exponential decay factor applied to older seasons.  Games from
+        the ``n``th file in ``paths`` are weighted by ``decay**n``.  Use
+        ``None`` to give all seasons equal weight.
 
     Returns
     -------
@@ -101,41 +109,47 @@ def estimate_team_strengths(paths: List[str]) -> Dict[str, tuple[float, float]]:
         Mapping of team name to ``(attack, defense)`` multipliers.
     """
 
-    df = [parse_matches(p) for p in paths]
-    if not df:
+    stats: Dict[str, Dict[str, float]] = {}
+
+    for n, path in enumerate(paths):
+        weight = 1.0 if decay is None else decay**n
+        if weight == 0:
+            continue
+        df = parse_matches(path)
+        played = df.dropna(subset=["home_score", "away_score"])
+
+        teams = pd.unique(played[["home_team", "away_team"]].values.ravel())
+        for t in teams:
+            stats.setdefault(t, {"gf": 0.0, "ga": 0.0, "w": 0.0})
+
+        for _, row in played.iterrows():
+            ht = row["home_team"]
+            at = row["away_team"]
+            hs = float(row["home_score"])
+            as_ = float(row["away_score"])
+            stats[ht]["gf"] += hs * weight
+            stats[ht]["ga"] += as_ * weight
+            stats[ht]["w"] += weight
+            stats[at]["gf"] += as_ * weight
+            stats[at]["ga"] += hs * weight
+            stats[at]["w"] += weight
+
+    if not stats:
         return {}
 
-    played = (
-        pd.concat(df, ignore_index=True)
-        .dropna(subset=["home_score", "away_score"])
-    )
-
-    teams = pd.unique(played[["home_team", "away_team"]].values.ravel())
-    stats = {t: {"gf": 0, "ga": 0, "games": 0} for t in teams}
-
-    for _, row in played.iterrows():
-        ht = row["home_team"]
-        at = row["away_team"]
-        hs = int(row["home_score"])
-        as_ = int(row["away_score"])
-        stats[ht]["gf"] += hs
-        stats[ht]["ga"] += as_
-        stats[ht]["games"] += 1
-        stats[at]["gf"] += as_
-        stats[at]["ga"] += hs
-        stats[at]["games"] += 1
-
     total_goals = sum(s["gf"] for s in stats.values())
-    total_games = sum(s["games"] for s in stats.values())
-    if total_games == 0:
+    total_weight = sum(s["w"] for s in stats.values())
+    if total_weight == 0:
         raise ValueError("No played games found in provided paths")
 
-    avg_goals = total_goals / total_games
+    avg_goals = total_goals / total_weight
 
     strengths: Dict[str, tuple[float, float]] = {}
     for team, s in stats.items():
-        attack = (s["gf"] / s["games"]) / avg_goals
-        defense = (s["ga"] / s["games"]) / avg_goals
+        if s["w"] == 0:
+            continue
+        attack = (s["gf"] / s["w"]) / avg_goals
+        defense = (s["ga"] / s["w"]) / avg_goals
         strengths[team] = (attack, defense)
 
     return strengths

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -27,6 +27,14 @@ def test_estimate_team_strengths_repeatable():
     assert round(strengths["Fluminense"][1], 4) == 0.8396
 
 
+def test_estimate_team_strengths_decay_zero_matches_latest_only():
+    s_latest = estimate_team_strengths(["data/Brasileirao2024A.txt"])
+    s_decay = estimate_team_strengths(
+        ["data/Brasileirao2024A.txt", "data/Brasileirao2023A.txt"], decay=0.0
+    )
+    assert s_latest == s_decay
+
+
 def test_estimate_goal_means_repeatable():
     hm, am = estimate_goal_means(["data/Brasileirao2024A.txt"])
     assert round(hm, 4) == 1.4105


### PR DESCRIPTION
## Summary
- add optional decay parameter to `estimate_team_strengths` and normalize weighted stats
- document season weighting example in README
- cover decay handling with regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689006c2fa008325a0342b3bd1d56f89