### PR TITLE
Validate match file markers

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -69,12 +69,17 @@ def parse_matches(path: str | Path) -> pd.DataFrame:
     """Return a DataFrame of fixtures and results."""
     rows: list[dict] = []
     in_games = False
+    saw_begin = False
+    saw_end = False
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
-            if line.strip() == "GamesBegin":
+            stripped = line.strip()
+            if stripped == "GamesBegin":
+                saw_begin = True
                 in_games = True
                 continue
-            if line.strip() == "GamesEnd":
+            if stripped == "GamesEnd":
+                saw_end = True
                 break
             if not in_games:
                 continue
@@ -104,6 +109,8 @@ def parse_matches(path: str | Path) -> pd.DataFrame:
                         "away_score": np.nan,
                     }
                 )
+    if not (saw_begin and saw_end):
+        raise ValueError("Matches file must contain 'GamesBegin' and 'GamesEnd' markers")
     return pd.DataFrame(rows)
 
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -13,6 +13,20 @@ def test_parse_matches():
     assert {'home_team', 'away_team', 'home_score', 'away_score'}.issubset(df.columns)
 
 
+def test_parse_matches_missing_begin(tmp_path):
+    p = tmp_path / "matches.txt"
+    p.write_text("Some header\nGamesEnd\n")
+    with pytest.raises(ValueError):
+        parse_matches(p)
+
+
+def test_parse_matches_missing_end(tmp_path):
+    p = tmp_path / "matches.txt"
+    p.write_text("GamesBegin\n")
+    with pytest.raises(ValueError):
+        parse_matches(p)
+
+
 def test_league_table():
     df = parse_matches('data/Brasileirao2024A.txt')
     table = league_table(df)


### PR DESCRIPTION
## Summary
- ensure parse_matches checks for `GamesBegin` and `GamesEnd` markers and raises errors on malformed files
- add tests covering missing `GamesBegin` or `GamesEnd` markers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890121c51648325acac3717996fe4d8