### PR TITLE
Optimize team parameter retrieval in simulation

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -261,8 +261,10 @@ def _simulate_table(
         tp = tie_prob
         ha = home_advantage
         if team_params is not None:
-            ha *= team_params.get(row["home_team"], (1.0, 1.0))[0] / team_params.get(row["away_team"], (1.0, 1.0))[1]
-            away_factor = team_params.get(row["away_team"], (1.0, 1.0))[0] / team_params.get(row["home_team"], (1.0, 1.0))[1]
+            home_att, home_def = team_params.get(row["home_team"], (1.0, 1.0))
+            away_att, away_def = team_params.get(row["away_team"], (1.0, 1.0))
+            ha *= home_att / away_def
+            away_factor = away_att / home_def
         else:
             away_factor = 1.0
 


### PR DESCRIPTION
## Summary
- Reduce repeated lookups in `_simulate_table` by caching home and away attack/defense parameters per match.
- Use cached values to compute home advantage and away factors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890130720c8832585b9b1b788eb5ddb