### PR TITLE
Validate iteration count for simulations

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -410,6 +410,9 @@ def simulate_chances(
 
     """
 
+    if iterations <= 0:
+        raise ValueError("iterations must be greater than 0")
+
     if rng is None:
         rng = np.random.default_rng()
 
@@ -460,6 +463,9 @@ def simulate_relegation_chances(
 ) -> Dict[str, float]:
     """Return probabilities of finishing in the bottom four."""
 
+    if iterations <= 0:
+        raise ValueError("iterations must be greater than 0")
+
     if rng is None:
         rng = np.random.default_rng()
 
@@ -509,6 +515,9 @@ def simulate_final_table(
     n_jobs: int = DEFAULT_JOBS,
 ) -> pd.DataFrame:
     """Project average finishing position and points."""
+
+    if iterations <= 0:
+        raise ValueError("iterations must be greater than 0")
 
     if rng is None:
         rng = np.random.default_rng()
@@ -576,6 +585,9 @@ def summary_table(
     The ``position`` column corresponds to the rank after sorting by the
     expected point totals.
     """
+
+    if iterations <= 0:
+        raise ValueError("iterations must be greater than 0")
 
     if rng is None:
         rng = np.random.default_rng()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -191,6 +191,22 @@ def test_simulate_chances_invalid_params():
         simulator.simulate_chances(df, iterations=1, home_advantage=0, progress=False)
 
 
+@pytest.mark.parametrize(
+    "func",
+    [
+        simulator.simulate_chances,
+        simulator.simulate_relegation_chances,
+        simulator.simulate_final_table,
+        simulator.summary_table,
+    ],
+)
+@pytest.mark.parametrize("iter_count", [0, -1])
+def test_iterations_must_be_positive(func, iter_count):
+    df = parse_matches("data/Brasileirao2024A.txt")
+    with pytest.raises(ValueError):
+        func(df, iterations=iter_count, progress=False)
+
+
 def test_simulate_final_table_custom_params_deterministic():
     df = parse_matches("data/Brasileirao2024A.txt")
     rng = np.random.default_rng(9)


### PR DESCRIPTION
## Summary
- raise `ValueError` when simulation functions receive non-positive iteration counts
- test that simulations error on zero or negative iteration values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68901520579083259f8b5e37b024cf1c