### PR TITLE
Add rho CLI option and reproducibility test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ command line. `DEFAULT_JOBS` still defines the parallelism level.
 Pass `--home-goals-mean` and `--away-goals-mean` to sample scores from Poisson
 distributions with the given expected values instead of the basic win/draw/loss
 model. These options can also be provided programmatically via the simulation
-functions. An optional `rho` parameter can be supplied alongside the expected
-goals to introduce correlation between the home and away scorelines.
+functions. Pass `--rho` to introduce correlation between the home and away
+scorelines when using Poisson scoring.
 
 Alternatively, pass `--auto-calibrate` to estimate these parameters using all
 historical files in the `data/` directory. The computed draw rate and home

--- a/main.py
+++ b/main.py
@@ -80,6 +80,12 @@ def main() -> None:
         help="expected goals for the away side when using Poisson scoring",
     )
     parser.add_argument(
+        "--rho",
+        type=float,
+        default=None,
+        help="correlação entre gols (Poisson)",
+    )
+    parser.add_argument(
         "--auto-calibrate",
         action="store_true",
         help="estimate parameters from past seasons",
@@ -138,6 +144,7 @@ def main() -> None:
         team_params=team_params,
         home_goals_mean=args.home_goals_mean,
         away_goals_mean=args.away_goals_mean,
+        rho=args.rho,
         n_jobs=args.jobs,
     )
     if args.html_output:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -442,6 +442,33 @@ def test_correlated_poisson_repeatable():
     pd.testing.assert_frame_equal(t1, t2)
 
 
+def test_final_table_correlated_poisson_repeatable():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    rng = np.random.default_rng(222)
+    t1 = simulator.simulate_final_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.3,
+        away_goals_mean=1.0,
+        rho=0.25,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(222)
+    t2 = simulator.simulate_final_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.3,
+        away_goals_mean=1.0,
+        rho=0.25,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
 def test_simulate_table_invalid_rho():
     played, remaining = _minimal_matches()
     rng = np.random.default_rng(10)


### PR DESCRIPTION
## Summary
- add `--rho` command-line argument to set correlation between home and away goals in Poisson scoring
- document `--rho` flag in README and pass value to `summary_table`
- add regression test ensuring `simulate_final_table` is repeatable when `rho` is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902214f1b4832597cc30bc01f02e57