### PR TITLE
Optimize Poisson quantile fallback

### DIFF
--- a/tests/test_poisson_ppf.py
+++ b/tests/test_poisson_ppf.py
@@ -8,7 +8,7 @@ import pytest
 
 # Add the src directory to the module search path so we can import simulator
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-from simulator import _poisson_ppf  # type: ignore
+import simulator  # type: ignore
 
 
 def _naive_poisson_ppf(u: float, lam: float) -> int:
@@ -27,17 +27,36 @@ def test_poisson_ppf_matches_scipy():
     for lam in [1, 5, 20, 1000]:
         us = np.linspace(0.01, 0.99, 5)
         for u in us:
-            assert _poisson_ppf(u, lam) == int(scipy_stats.poisson.ppf(u, lam))
+            assert simulator._poisson_ppf(u, lam) == int(scipy_stats.poisson.ppf(u, lam))
 
 
-def test_poisson_ppf_speed():
-    pytest.importorskip("scipy.stats")
-    lam = 1000.0
+def test_poisson_ppf_uses_scipy(monkeypatch):
+    scipy_stats = pytest.importorskip("scipy.stats")
+    calls = {"count": 0}
+
+    original = scipy_stats.poisson.ppf
+
+    def fake_ppf(u, lam):
+        calls["count"] += 1
+        return original(u, lam)
+
+    monkeypatch.setattr(scipy_stats.poisson, "ppf", fake_ppf)
+    simulator._poisson_ppf(0.5, 5.0)
+    assert calls["count"] == 1
+
+
+def test_poisson_ppf_fallback_speed(monkeypatch):
+    """Optimised fallback should beat the old cumulative loop."""
+
+    monkeypatch.setattr(simulator, "_scipy_poisson", None)
+    simulator._poisson_cdf_array.cache_clear()
+
+    lam = 50.0
     us = np.random.default_rng(0).random(1000)
 
     start = time.time()
     for u in us:
-        _poisson_ppf(u, lam)
+        simulator._poisson_ppf(u, lam)
     new_time = time.time() - start
 
     start = time.time()
@@ -45,5 +64,4 @@ def test_poisson_ppf_speed():
         _naive_poisson_ppf(u, lam)
     old_time = time.time() - start
 
-    # SciPy-backed implementation should be faster than naive fallback
     assert new_time < old_time


### PR DESCRIPTION
## Summary
- replace iterative Poisson quantile fallback with cached NumPy implementation using log-probabilities and binary search
- ensure SciPy's ppf is invoked when available and add performance test for fallback path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890241676388325b4cc79991b155ab5