### PR TITLE
Add top-four finish projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brasileirão Simulator
 
-This project provides a simple simulator for the 2025 Brasileirão Série A season. It parses the fixtures provided in `data/Brasileirao2025A.txt`, builds a league table from played matches and simulates the remaining games many times to estimate title and relegation probabilities.
+This project provides a simple simulator for the 2025 Brasileirão Série A season. It parses the fixtures provided in `data/Brasileirao2025A.txt`, builds a league table from played matches and simulates the remaining games many times to estimate title, top-four and relegation probabilities.
 
 ## Usage
 
@@ -63,7 +63,7 @@ By default matches are simulated purely at random with all teams considered
 equal. When expected goals are supplied the scores are drawn from Poisson
 distributions using those averages.
 
-The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.
+The script outputs the estimated chance of winning the title and of finishing in the top four for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.
 All of these metrics are derived from a single Monte Carlo loop so that title chances, relegation odds and projected points remain consistent.
 
 ## Tie-break Rules

--- a/main.py
+++ b/main.py
@@ -151,18 +151,20 @@ def main() -> None:
         summary.to_html(args.html_output, index=False)
 
     TITLE_W = 7
+    TOP4_W = 7
     REL_W = 10
     POINTS_W = len("xPts")
     WINS_W = len("xWins")
     GD_W = len("xGD")
     print(
-        f"{'Pos':>3}  {'Team':15s} {'xPts':^{POINTS_W}} {'xWins':^{WINS_W}} {'xGD':^{GD_W}} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}"
+        f"{'Pos':>3}  {'Team':15s} {'xPts':^{POINTS_W}} {'xWins':^{WINS_W}} {'xGD':^{GD_W}} {'Title':^{TITLE_W}} {'Top4':^{TOP4_W}} {'Relegation':^{REL_W}}"
     )
     for _, row in summary.iterrows():
         title = f"{row['title']:.2%}"
+        top4 = f"{row['top4']:.2%}"
         releg = f"{row['relegation']:.2%}"
         print(
-            f"{row['position']:>2d}   {row['team']:15s} {row['points']:^{POINTS_W}d} {row['wins']:^{WINS_W}d} {row['gd']:^{GD_W}d} {title:^{TITLE_W}} {releg:^{REL_W}}"
+            f"{row['position']:>2d}   {row['team']:15s} {row['points']:^{POINTS_W}d} {row['wins']:^{WINS_W}d} {row['gd']:^{GD_W}d} {title:^{TITLE_W}} {top4:^{TOP4_W}} {releg:^{REL_W}}"
         )
 
 if __name__ == "__main__":

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -643,6 +643,7 @@ def summary_table(
 
     teams = pd.unique(matches[["home_team", "away_team"]].values.ravel())
     title_counts = {t: 0 for t in teams}
+    top4_counts = {t: 0 for t in teams}
     relegated = {t: 0 for t in teams}
     points_totals = {t: 0.0 for t in teams}
     wins_totals = {t: 0.0 for t in teams}
@@ -669,6 +670,8 @@ def summary_table(
         n_jobs=n_jobs,
     ):
         title_counts[table.iloc[0]["team"]] += 1
+        for team in table.head(4)["team"]:
+            top4_counts[team] += 1
         for team in table.tail(4)["team"]:
             relegated[team] += 1
         for _, row in table.iterrows():
@@ -685,6 +688,7 @@ def summary_table(
                 "wins": wins_totals[team] / iterations,
                 "gd": gd_totals[team] / iterations,
                 "title": title_counts[team] / iterations,
+                "top4": top4_counts[team] / iterations,
                 "relegation": relegated[team] / iterations,
             }
         )
@@ -695,4 +699,4 @@ def summary_table(
     df["points"] = df["points"].round().astype(int)
     df["wins"] = df["wins"].round().astype(int)
     df["gd"] = df["gd"].round().astype(int)
-    return df[["position", "team", "points", "wins", "gd", "title", "relegation"]]
+    return df[["position", "team", "points", "wins", "gd", "title", "top4", "relegation"]]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -117,8 +117,15 @@ def test_summary_table_deterministic():
         "wins",
         "gd",
         "title",
+        "top4",
         "relegation",
     }.issubset(table1.columns)
+
+
+def test_summary_table_top4_probabilities_sum_to_four():
+    df = parse_matches('data/Brasileirao2024A.txt')
+    table = simulator.summary_table(df, iterations=10, progress=False, n_jobs=2)
+    assert abs(table['top4'].sum() - 4.0) < 1e-6
 
 
 def test_league_table_tiebreakers():


### PR DESCRIPTION
## Summary
- track top-four finishes in simulation summary
- display new %Top4 column in CLI output
- document top-four probability in README
- test determinism and probability sum for top-four metric

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689027deb2908325915de6c2c1613601