### PR TITLE
Raise error on unknown match lines

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -90,6 +90,9 @@ def parse_matches(path: str | Path) -> pd.DataFrame:
             if not in_games:
                 continue
             line = line.rstrip("\n")
+            # Skip known metadata lines that may appear within the games section
+            if not line or line.startswith("TeamListedFirst:"):
+                continue
             m = SCORE_PATTERN.match(line)
             if m:
                 date_str, home, hs, as_, away = m.groups()
@@ -115,6 +118,10 @@ def parse_matches(path: str | Path) -> pd.DataFrame:
                         "away_score": np.nan,
                     }
                 )
+                continue
+            # Any line within the Games section that doesn't match one of the
+            # expected patterns should trigger an error to aid debugging.
+            raise ValueError(f"Unrecognized line in matches file: {line}")
     if not (saw_begin and saw_end):
         raise ValueError("Matches file must contain 'GamesBegin' and 'GamesEnd' markers")
     return pd.DataFrame(rows)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -27,6 +27,13 @@ def test_parse_matches_missing_end(tmp_path):
         parse_matches(p)
 
 
+def test_parse_matches_invalid_line(tmp_path):
+    p = tmp_path / "matches.txt"
+    p.write_text("GamesBegin\ninvalid stuff\nGamesEnd\n")
+    with pytest.raises(ValueError, match="invalid stuff"):
+        parse_matches(p)
+
+
 def test_league_table():
     df = parse_matches('data/Brasileirao2024A.txt')
     table = league_table(df)


### PR DESCRIPTION
## Summary
- validate fixture parsing by raising `ValueError` for lines that do not match expected patterns
- cover parsing error path with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902dbd11b08325b077edc6c6050262