### PR TITLE
feat: estimate goal correlation

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from calibration import (
     estimate_parameters,
     estimate_goal_means,
     estimate_team_strengths,
+    estimate_rho,
 )
 
 
@@ -120,6 +121,7 @@ def main() -> None:
         season_files = season_files or []
         args.tie_percent, args.home_advantage = estimate_parameters(season_files)
         args.home_goals_mean, args.away_goals_mean = estimate_goal_means(season_files)
+        args.rho = estimate_rho(season_files)
 
     team_params = None
     if args.auto_team_strengths:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,7 +12,12 @@ from .simulator import (
     DEFAULT_HOME_FIELD_ADVANTAGE,
     DEFAULT_JOBS,
 )
-from .calibration import estimate_parameters, estimate_team_strengths, estimate_goal_means
+from .calibration import (
+    estimate_parameters,
+    estimate_team_strengths,
+    estimate_goal_means,
+    estimate_rho,
+)
 
 __all__ = [
     "parse_matches",
@@ -28,4 +33,5 @@ __all__ = [
     "estimate_parameters",
     "estimate_team_strengths",
     "estimate_goal_means",
+    "estimate_rho",
 ]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -2,7 +2,12 @@ import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(
 
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from calibration import estimate_parameters, estimate_team_strengths, estimate_goal_means
+from calibration import (
+    estimate_parameters,
+    estimate_team_strengths,
+    estimate_goal_means,
+    estimate_rho,
+)
 
 
 def test_estimate_parameters_repeatable():
@@ -66,4 +71,25 @@ def test_estimate_goal_means_decay_zero_matches_latest_only():
     )
     assert hm_latest == hm_decay
     assert am_latest == am_decay
+
+
+def test_estimate_rho_repeatable():
+    rho = estimate_rho(["data/Brasileirao2024A.txt"])
+    assert round(rho, 4) == -0.06
+
+
+def test_estimate_rho_multiple_files_repeatable():
+    rho = estimate_rho([
+        "data/Brasileirao2023A.txt",
+        "data/Brasileirao2024A.txt",
+    ])
+    assert round(rho, 4) == -0.014
+
+
+def test_estimate_rho_decay_zero_matches_latest_only():
+    rho_latest = estimate_rho(["data/Brasileirao2024A.txt"])
+    rho_decay = estimate_rho(
+        ["data/Brasileirao2024A.txt", "data/Brasileirao2023A.txt"], decay=0.0
+    )
+    assert rho_latest == rho_decay
 


### PR DESCRIPTION
## Summary
- add estimate_rho for correlation of home and away goals
- auto-calibrate rho in CLI
- cover rho estimation with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902e76878c8325b197c8396c4221eb