### PR TITLE
Enable automatic team-strength estimation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ simulate from that point forward. Use `--auto-calibrate` to derive the draw
 percentage and home advantage from past seasons before running the simulation.
 When this flag is supplied, every file matching `data/Brasileirao????A.txt` is
 loaded automatically (except the file provided via `--file`).
-Pass `--auto-team-strengths` to compute attack and defense multipliers for each
-club from those same historical files and include them in the simulation.
+Team strengths are computed automatically from the same historical files and
+included in the simulation. Use `--no-auto-team-strengths` to skip this
+estimation.
 
 The default draw rate and home-field advantage are
 `DEFAULT_TIE_PERCENT` (33.3) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.0).
@@ -41,8 +42,8 @@ scorelines when using Poisson scoring.
 
 Alternatively, pass `--auto-calibrate` to estimate these parameters using all
 historical files in the `data/` directory. The computed draw rate and home
-advantage are then used for the simulation. Combine this flag with
-`--auto-team-strengths` to automatically incorporate team quality estimates.
+advantage are then used for the simulation. Team quality estimates are included
+by default; supply `--no-auto-team-strengths` to omit them.
 
 Use ``estimate_team_strengths`` to calculate attack and defense multipliers for
 each club.  Pass multiple seasons and an optional ``decay`` factor to weigh

--- a/main.py
+++ b/main.py
@@ -92,9 +92,13 @@ def main() -> None:
         help="estimate parameters from past seasons",
     )
     parser.add_argument(
-        "--auto-team-strengths",
-        action="store_true",
-        help="estimate attack and defense multipliers from past seasons",
+        "--no-auto-team-strengths",
+        action="store_false",
+        dest="auto_team_strengths",
+        default=True,
+        help=(
+            "disable automatic attack and defense multiplier estimation from past seasons"
+        ),
     )
     parser.add_argument(
         "--from-date",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,19 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import main
+
+
+def test_auto_team_strengths_runs_by_default(monkeypatch):
+    called = {"value": False}
+
+    def fake_estimate_team_strengths(files):
+        called["value"] = True
+        return {}
+
+    monkeypatch.setattr(main, "estimate_team_strengths", fake_estimate_team_strengths)
+    monkeypatch.setattr(main, "parse_matches", lambda path: pd.DataFrame())
+    monkeypatch.setattr(main, "summary_table", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(sys, "argv", ["main.py", "--simulations", "1", "--html-output", ""])
+    main.main()
+    assert called["value"]


### PR DESCRIPTION
## Summary
- Automatically estimate team strengths in the CLI unless disabled with `--no-auto-team-strengths`
- Document default team-strength estimation and new opt-out flag in README
- Add unit test ensuring team-strength estimation runs when no flag is given

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890329b42488325a53c8a15d9da69d2